### PR TITLE
Fixes to Distribution History and Link Distribution

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -114,6 +114,21 @@ assert_surveyFile_exists <- function(file_name) {
   )
 }
 
+# Check that distribution is parent distribution
+
+assert_parent_distribution <- function(distributionID, surveyID) {
+
+  fetch_url <- create_distribution_url(base_url = Sys.getenv("QUALTRICS_BASE_URL"),
+                                       distributionId = distributionID,
+                                       surveyId = surveyID)
+  x <- qualtrics_api_request("GET", url = fetch_url)
+
+  assertthat::assert_that(is.null(x$result$parentDistributionId),
+                          msg = "distributionID not parent distribution"
+
+  )
+}
+
 # Check if these arguments are logical
 assert_options_logical <- function(verbose,
                                    convert,

--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -1,0 +1,60 @@
+
+#' Download distribution history data for a distribution from Qualtrics
+#'
+#' @param distributionID String. Unique distribution ID for the distribution history you want to download.
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Register your Qualtrics credentials if you haven't already
+#' qualtrics_api_credentials(
+#'   api_key = "<YOUR-API-KEY>",
+#'   base_url = "<YOUR-BASE-URL>"
+#' )
+#'
+#' surveys <- all_surveys()
+#' distributions <- fetch_distributions(surveys$id[1])
+#' distribution_history <- fetch_distribution_history(distributions$id[1])
+#'}
+#'
+
+fetch_distribution_history <- function(distributionID){
+
+  # qualtrics distribution history parameters can be found at https://api.qualtrics.com/guides/reference/distributions.json/paths/~1distributions~1%7BdistributionId%7D~1history/get
+
+  assert_base_url()
+  assert_api_key()
+
+  fetch_url <- create_distribution_history_url(base_url = Sys.getenv("QUALTRICS_BASE_URL"),
+                                               distributionID = distributionID)
+
+  elements <- list()
+
+  while(!is.null(fetch_url)){
+
+    res <- qualtrics_api_request("GET", url = fetch_url)
+    elements <- append(elements, res$result$elements)
+    fetch_url <- res$result$nextPage
+
+  }
+
+  elements <- res$result$elements
+
+  x <- tibble::tibble(contactId = purrr::map_chr(elements, "contactId", .default = NA_character_),
+                      contactLookupId = purrr::map_chr(elements, "contactLookupId", .default = NA_character_),
+                      distributionID = purrr::map_chr(elements, "distributionID", .default = NA_character_),
+                      status = purrr::map_chr(elements, "status", .default = NA_character_),
+                      surveyLink = purrr::map_chr(elements, "surveyLink", .default = NA_character_),
+                      contactFrequencyRuleId = purrr::map_chr(elements, "contactFrequencyRuleId", .default = NA_character_),
+                      responseId = purrr::map_chr(elements, "responseId", .default = NA_character_),
+                      responseCompletedAt = purrr::map_chr(elements, "responseCompletedAt", .default = NA_character_),
+                      sentAt = purrr::map_chr(elements, "sentAt", .default = NA_character_),
+                      openedAt = purrr::map_chr(elements, "openedAt", .default = NA_character_),
+                      responseStartedAt = purrr::map_chr(elements, "responseStartedAt", .default = NA_character_),
+                      surveySessionId = purrr::map_chr(elements, "surveySessionId", .default = NA_character_))
+
+  return(x)
+
+}
+

--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -19,15 +19,17 @@
 #'}
 #'
 
-fetch_distribution_history <- function(distributionID){
+fetch_distribution_history <- function(distributionID, surveyID){
 
   # qualtrics distribution history parameters can be found at https://api.qualtrics.com/guides/reference/distributions.json/paths/~1distributions~1%7BdistributionId%7D~1history/get
 
   assert_base_url()
   assert_api_key()
+  assert_parent_distribution(distributionID = distributionID,
+                             surveyID = surveyID)
 
   fetch_url <- create_distribution_history_url(base_url = Sys.getenv("QUALTRICS_BASE_URL"),
-                                               distributionID = distributionID)
+                                               distributionId = distributionID)
 
   elements <- list()
 
@@ -51,6 +53,15 @@ fetch_distribution_history <- function(distributionID){
                       openedAt = purrr::map_chr(elements, "openedAt", .default = NA_character_),
                       responseStartedAt = purrr::map_chr(elements, "responseStartedAt", .default = NA_character_),
                       surveySessionId = purrr::map_chr(elements, "surveySessionId", .default = NA_character_))
+
+  links <- list_distribution_links(base_url = Sys.getenv("QUALTRICS_BASE_URL"),
+                                   distributionId = distributionID,
+                                   surveyId = surveyID)
+
+  links <- dplyr::select(links, contactId, email, linkExpiration, lastName,
+                         firstName, externalDataReference, unsubscribed)
+
+  x <- dplyr::left_join(x, links, by = "contactId")
 
   return(x)
 

--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -55,8 +55,8 @@ fetch_distribution_history <- function(distributionID, surveyID){
                       surveySessionId = purrr::map_chr(elements, "surveySessionId", .default = NA_character_))
 
   links <- list_distribution_links(base_url = Sys.getenv("QUALTRICS_BASE_URL"),
-                                   distributionId = distributionID,
-                                   surveyId = surveyID)
+                                   distributionID = distributionID,
+                                   surveyID = surveyID)
 
   links <- dplyr::select(links, contactId, email, linkExpiration, lastName,
                          firstName, externalDataReference, unsubscribed)

--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -39,8 +39,6 @@ fetch_distribution_history <- function(distributionID){
 
   }
 
-  elements <- res$result$elements
-
   x <- tibble::tibble(contactId = purrr::map_chr(elements, "contactId", .default = NA_character_),
                       contactLookupId = purrr::map_chr(elements, "contactLookupId", .default = NA_character_),
                       distributionID = purrr::map_chr(elements, "distributionID", .default = NA_character_),

--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -33,6 +33,7 @@ fetch_distribution_history <- function(distributionID, surveyID){
 
   elements <- list()
   iter <- 1
+  message("Getting Distribution History")
   while(!is.null(fetch_url)){tryCatch({
     attempt_fetch <- 1
     while(attempt_fetch != 4){
@@ -53,7 +54,7 @@ fetch_distribution_history <- function(distributionID, surveyID){
 
   x <- tibble::tibble(contactId = purrr::map_chr(elements, "contactId", .default = NA_character_),
                       contactLookupId = purrr::map_chr(elements, "contactLookupId", .default = NA_character_),
-                      distributionID = purrr::map_chr(elements, "distributionID", .default = NA_character_),
+                      distributionId = purrr::map_chr(elements, "distributionId", .default = NA_character_),
                       status = purrr::map_chr(elements, "status", .default = NA_character_),
                       surveyLink = purrr::map_chr(elements, "surveyLink", .default = NA_character_),
                       contactFrequencyRuleId = purrr::map_chr(elements, "contactFrequencyRuleId", .default = NA_character_),
@@ -63,15 +64,15 @@ fetch_distribution_history <- function(distributionID, surveyID){
                       openedAt = purrr::map_chr(elements, "openedAt", .default = NA_character_),
                       responseStartedAt = purrr::map_chr(elements, "responseStartedAt", .default = NA_character_),
                       surveySessionId = purrr::map_chr(elements, "surveySessionId", .default = NA_character_))
-# message("links")
-#   links <- list_distribution_links(#base_url = Sys.getenv("QUALTRICS_BASE_URL"),
-#                                    distributionID = distributionID,
-#                                    surveyID = surveyID)
-#
-#   links <- dplyr::select(links, contactId, email, linkExpiration, lastName,
-#                          firstName, externalDataReference, unsubscribed)
-#
-#   x <- dplyr::left_join(x, links, by = "contactId")
+
+  message("Getting distribution links (email for each contact)")
+  links <- list_distribution_links(distributionID = distributionID,
+                                   surveyID = surveyID)
+
+  links <- dplyr::select(links, contactId, email, linkExpiration, lastName,
+                         firstName, externalDataReference, unsubscribed)
+
+  x <- dplyr::left_join(x, links, by = "contactId")
 
   return(x)
 

--- a/R/list_distribution_links.R
+++ b/R/list_distribution_links.R
@@ -1,0 +1,57 @@
+
+#' Download distribution links for a distribution from Qualtrics
+#'
+#' @param distributionID String. Unique distribution ID for the distribution links you want to download.
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Register your Qualtrics credentials if you haven't already
+#' qualtrics_api_credentials(
+#'   api_key = "<YOUR-API-KEY>",
+#'   base_url = "<YOUR-BASE-URL>"
+#' )
+#'
+#' surveys <- all_surveys()
+#' distributions <- fetch_distributions(surveys$id[1])
+#' distribution_links <- list_distribution_links(distributions$id[1], surveyID = surveys$id[1])
+#'}
+#'
+
+list_distribution_links <- function(distributionID, surveyID){
+
+  # qualtrics distribution links parameters can be found at https://api.qualtrics.com/guides/reference/distributions.json/paths/~1distributions~1%7BdistributionId%7D~1links/get
+
+  assert_base_url()
+  assert_api_key()
+  assert_parent_distribution(distributionID = distributionID,
+                             surveyID = surveyID)
+
+  fetch_url <- create_distribution_links_url(base_url = Sys.getenv("QUALTRICS_BASE_URL"),
+                                             distributionId = distributionID,
+                                             surveyId = surveyID)
+
+  elements <- list()
+
+  while(!is.null(fetch_url)){
+
+    res <- qualtrics_api_request("GET", url = fetch_url)
+    elements <- append(elements, res$result$elements)
+    fetch_url <- res$result$nextPage
+
+  }
+
+  x <- tibble::tibble(contactId = purrr::map_chr(elements, "contactId", .default = NA_character_),
+                      link = purrr::map_chr(elements, "link", .default = NA_character_),
+                      exceededContactFrequency = purrr::map_chr(elements, "exceededContactFrequency", .default = NA_character_),
+                      linkExpiration = purrr::map_chr(elements, "linkExpiration", .default = NA_character_),
+                      lastName = purrr::map_chr(elements, "lastName", .default = NA_character_),
+                      firstName = purrr::map_chr(elements, "firstName", .default = NA_character_),
+                      externalDataReference = purrr::map_chr(elements, "externalDataReference", .default = NA_character_),
+                      email = purrr::map_chr(elements, "email", .default = NA_character_),
+                      unsubscribed = purrr::map_chr(elements, "unsubscribed", .default = NA_character_))
+
+  return(x)
+
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -248,6 +248,16 @@ create_distributions_url <- function(base_url, surveyID){
   return(distributions_url)
 }
 
+create_distribution_history_url <- function(base_url, distributionId){
+  # create url
+  distribution_history_url <-
+    paste0(
+      create_root_url(base_url),
+      "distributions/", distributionId, "/history"
+    )
+  return(distribution_history_url)
+}
+
 #' Create raw JSON payload to post response exports request
 #'
 #' @param label Flag

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,6 +238,16 @@ create_mailinglist_url <- function(base_url, mailinglistID){
   return(mailinglist_url)
 }
 
+create_distribution_url <- function(base_url, distributionId, surveyId){
+  # create url
+  distribution_url <-
+    paste0(
+      create_root_url(base_url),
+      "distributions/", distributionId, "?surveyId=", surveyID
+    )
+  return(distribution_url)
+}
+
 create_distributions_url <- function(base_url, surveyID){
   # create url
   distributions_url <-
@@ -256,6 +266,16 @@ create_distribution_history_url <- function(base_url, distributionId){
       "distributions/", distributionId, "/history"
     )
   return(distribution_history_url)
+}
+
+create_distribution_links_url <- function(base_url, distributionId, surveyId){
+  # create url
+  distribution_links_url <-
+    paste0(
+      create_root_url(base_url),
+      "distributions/", distributionId, "/links?surveyId=", surveyId
+    )
+  return(distribution_links_url)
 }
 
 #' Create raw JSON payload to post response exports request

--- a/R/utils.R
+++ b/R/utils.R
@@ -243,7 +243,7 @@ create_distribution_url <- function(base_url, distributionId, surveyId){
   distribution_url <-
     paste0(
       create_root_url(base_url),
-      "distributions/", distributionId, "?surveyId=", surveyID
+      "distributions/", distributionId, "?surveyId=", surveyId
     )
   return(distribution_url)
 }


### PR DESCRIPTION
The api retry stuff may be a bit heavy-handed for ultimate inclusion in the package. IMO it needs to be in there, in some form-- but perhaps a less "chatty" version.

Fixed distributionId column name

Added the links call back to the history function. I've tested this myself on a distribution with 30000 emails and it works well.